### PR TITLE
divide as float instead

### DIFF
--- a/sparsnas_decode.cpp
+++ b/sparsnas_decode.cpp
@@ -192,8 +192,8 @@ public:
         } else if (data4 == 0 ) { // special mode for low power usage
           watt = effect * 0.24 / PULSES_PER_KWH;
         }
-        m += sprintf(m, "{\"Sequence\": %5d,\"Watt\": %7.2f,\"kWh\": %d.%.3d,\"battery\": %d,\"FreqErr\": %.2f,\"Effect\": %d,\"Data4\": %d",
-            seq, watt, pulse/PULSES_PER_KWH, pulse%PULSES_PER_KWH, battery, freq, effect, data4);
+        m += sprintf(m, "{\"Sequence\": %5d,\"Watt\": %7.2f,\"kWh\": %.3f,\"battery\": %d,\"FreqErr\": %.2f,\"Effect\": %d,\"Data4\": %d",
+            seq, watt, pulse/(float)PULSES_PER_KWH, battery, freq, effect, data4);
         if (testing && crc == packet_crc) {
           error_sum += fabs(freq);
           error_sum_count += 1;


### PR DESCRIPTION
`"%d.%.3", pulse/PULSES_PER_KWH, pulse%PULSES_PER_KWH` 

Will generate wrong kWh when `PULSES_PER_KWH` is larger than 9999.

Patch applied at ~10:55
<img width="632" alt="Screenshot 2019-03-22 at 11 46 37 " src="https://user-images.githubusercontent.com/676999/54817889-43ef3180-4c98-11e9-94ac-00841e95f57a.png">