### PR TITLE
Fix timeout issues with latest Alpine Edge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/te
       zsh
 
 COPY --from=BUILD_ENV /build/sparsnas_decode /usr/bin/
-
 COPY sparsnas.sh /
 
 RUN sed -i "s/^SENSORS=.*/SENSORS=(${SENSORS})/" /sparsnas.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 #  --build-arg MQTT_HOST=192.168.x.x --build-arg MQTT_PORT=1883 \
 #  --build-arg=MQTT_USERNAME=username --build-arg=MQTT_PASSWORD=hemligt
 
-FROM alpine:edge as BUILD_ENV
+FROM alpine:3.7 as BUILD_ENV
 
 COPY ./sparsnas_decode.cpp /build/
 
 RUN apk add --no-cache g++ mosquitto-dev && \
     g++ -o /build/sparsnas_decode -O2 -Wall /build/sparsnas_decode.cpp -lmosquitto
 
-FROM alpine:edge
+FROM alpine:3.7
 
 ARG SENSORS
 ARG MQTT_HOST

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,13 +23,14 @@ ENV MQTT_PASSWORD=$MQTT_PASSWORD
 
 RUN : "${SENSORS:?Build argument 'SENSORS' needs to be set and non-empty.}"
 
-COPY --from=BUILD_ENV /build/sparsnas_decode /usr/bin/
-COPY sparsnas.sh /
-
 RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing/ --allow-untrusted \
       rtl-sdr \
       mosquitto-libs++ \
       zsh
+
+COPY --from=BUILD_ENV /build/sparsnas_decode /usr/bin/
+
+COPY sparsnas.sh /
 
 RUN sed -i "s/^SENSORS=.*/SENSORS=(${SENSORS})/" /sparsnas.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@
 #  --build-arg MQTT_HOST=192.168.x.x --build-arg MQTT_PORT=1883 \
 #  --build-arg=MQTT_USERNAME=username --build-arg=MQTT_PASSWORD=hemligt
 
-FROM alpine:3.7 as BUILD_ENV
+FROM alpine:edge as BUILD_ENV
 
 COPY ./sparsnas_decode.cpp /build/
 
 RUN apk add --no-cache g++ mosquitto-dev && \
     g++ -o /build/sparsnas_decode -O2 -Wall /build/sparsnas_decode.cpp -lmosquitto
 
-FROM alpine:3.7
+FROM alpine:edge
 
 ARG SENSORS
 ARG MQTT_HOST

--- a/sparsnas.sh
+++ b/sparsnas.sh
@@ -55,7 +55,7 @@ if ( frequencies ); then
   eval $CMD
 else
   echo "Need to find frequencies"
-  busybox timeout -t 45 $RTL_SDR > /tmp/sparsnas.raw
+  busybox timeout 45 $RTL_SDR > /tmp/sparsnas.raw
   #ls -l /tmp/sparsnas.raw
   F=`findfreq`
   # echo $F


### PR DESCRIPTION
`sparsnas.sh` doesn't run on current Alpine Edge. This PR pins the version to 3.7 where it still works, however it doesn't fix the underlying issue.

The issue was (IIRC) in line 54 where the command `busybox timeout` fails.

Also reordered commands to utilize Docker caching a bit better.